### PR TITLE
Features/kafka

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,48 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=0000
+  zookeeper_t1:
+    image: confluentinc/cp-zookeeper:5.5.0
+    hostname: zookeeper_t1
+    container_name: zookeeper_t1
+    ports:
+      - "2182:2182"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2182
+      ZOOKEEPER_TICK_TIME: 2000
+  broker_t1:
+    image: confluentinc/cp-kafka:5.5.0
+    hostname: broker_t1
+    container_name: broker_t1
+    depends_on:
+      - zookeeper_t1
+    ports:
+      - "29092:29092"
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper_t1:2182'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker_t1:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+  broker_2_t1:
+    image: confluentinc/cp-kafka:5.5.0
+    hostname: broker_2_t1
+    container_name: broker_2_t1
+    depends_on:
+      - zookeeper_t1
+    ports:
+      - "29093:29092"
+      - "9093:9092"
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper_t1:2182'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker_2_t1:29093,PLAINTEXT_HOST://localhost:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0

--- a/src/main/java/ru/t1/java/demo/aop/LogDataSourceError.java
+++ b/src/main/java/ru/t1/java/demo/aop/LogDataSourceError.java
@@ -1,0 +1,12 @@
+package ru.t1.java.demo.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LogDataSourceError {
+
+}

--- a/src/main/java/ru/t1/java/demo/aop/LogDataSourceErrorAspect.java
+++ b/src/main/java/ru/t1/java/demo/aop/LogDataSourceErrorAspect.java
@@ -1,39 +1,33 @@
 package ru.t1.java.demo.aop;
 
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 import ru.t1.java.demo.model.DataSourceErrorLog;
 import ru.t1.java.demo.repository.DataSourceErrorLogRepository;
 
-import java.util.Arrays;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
-
-@Data
+@Slf4j
 @Aspect
 @Component
-@Slf4j
 public class LogDataSourceErrorAspect {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final DataSourceErrorLogRepository errorLogRepository;
 
-    @Value("${t1.kafka.topic.metrics}")
-    private String metricsTopic;
+    @Value("${t1.kafka.topic.errors}")
+    private String errorTopic;
 
-    public LogDataSourceErrorAspect(KafkaTemplate<String, String> kafkaTemplate,
-                                    DataSourceErrorLogRepository errorLogRepository) {
+    public LogDataSourceErrorAspect(KafkaTemplate<String, String> kafkaTemplate, DataSourceErrorLogRepository errorLogRepository) {
         this.kafkaTemplate = kafkaTemplate;
         this.errorLogRepository = errorLogRepository;
     }
-
 
     @Around("@annotation(LogDataSourceError)")
     public Object logErrorAndSendToKafka(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -41,37 +35,43 @@ public class LogDataSourceErrorAspect {
             return joinPoint.proceed();
         } catch (Exception ex) {
             log.error("Ошибка при выполнении метода: {}", ex.getMessage(), ex);
-            sendErrorToKafka(ex, joinPoint);
-            saveErrorToDatabase(ex, joinPoint);
+            boolean kafkaFailed = !sendErrorToKafka(ex, joinPoint);
+            if (kafkaFailed) {
+                saveErrorToDatabase(ex, joinPoint);
+            }
             throw ex;
         }
     }
 
-    private void sendErrorToKafka(Exception ex, ProceedingJoinPoint joinPoint) {
+    private boolean sendErrorToKafka(Exception ex, ProceedingJoinPoint joinPoint) {
         try {
-            String message = String.format(
-                    "Error in method: %s, Message: %s, StackTrace: %s",
-                    joinPoint.getSignature().getName(),
-                    ex.getMessage(),
-                    Arrays.toString(ex.getStackTrace())
-            );
-            Message<String> kafkaMessage = MessageBuilder.withPayload(message)
-                    .setHeader("errorType", "DATA_SOURCE")
-                    .build();
-            kafkaTemplate.send(metricsTopic, String.valueOf(kafkaMessage)).get();
-        } catch (Exception e) {
-            log.error("Не удалось отправить сообщение в Kafka: {}", e.getMessage(), e);
+            String methodName = joinPoint.getSignature().toShortString();
+            String message = String.format("Ошибка в методе %s: %s", methodName, ex.getMessage());
+            kafkaTemplate.send(errorTopic, message);
+            return true; // Kafka отправка успешна
+        } catch (Exception kafkaEx) {
+            log.error("Не удалось отправить ошибку в Kafka: {}", kafkaEx.getMessage(), kafkaEx);
+            return false; // Kafka отправка провалилась
         }
     }
 
     private void saveErrorToDatabase(Exception ex, ProceedingJoinPoint joinPoint) {
-        DataSourceErrorLog errorLog = new DataSourceErrorLog(
-                Arrays.toString(ex.getStackTrace()),
-                ex.getMessage(),
-                joinPoint.getSignature().toString()
-        );
+        String methodName = joinPoint.getSignature().toShortString();
+        DataSourceErrorLog errorLog = DataSourceErrorLog.builder()
+                .stackTrace(getStackTraceAsString(ex))
+                .message(ex.getMessage())
+                .methodSignature(methodName)
+                .build();
         errorLogRepository.save(errorLog);
+        log.info("Ошибка записана в базу данных: {}", errorLog);
+    }
+
+    private String getStackTraceAsString(Exception ex) {
+        StringWriter sw = new StringWriter();
+        ex.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
     }
 }
+
 
 

--- a/src/main/java/ru/t1/java/demo/aop/LogDataSourceErrorAspect.java
+++ b/src/main/java/ru/t1/java/demo/aop/LogDataSourceErrorAspect.java
@@ -1,43 +1,77 @@
 package ru.t1.java.demo.aop;
 
-import org.aspectj.lang.annotation.AfterThrowing;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 import ru.t1.java.demo.model.DataSourceErrorLog;
-import org.springframework.beans.factory.annotation.Autowired;
 import ru.t1.java.demo.repository.DataSourceErrorLogRepository;
 
+import java.util.Arrays;
+
+
+@Data
 @Aspect
 @Component
+@Slf4j
 public class LogDataSourceErrorAspect {
 
+    private final KafkaTemplate<String, String> kafkaTemplate;
     private final DataSourceErrorLogRepository errorLogRepository;
 
-    @Autowired
-    public LogDataSourceErrorAspect(DataSourceErrorLogRepository errorLogRepository) {
+    @Value("${t1.kafka.topic.metrics}")
+    private String metricsTopic;
+
+    public LogDataSourceErrorAspect(KafkaTemplate<String, String> kafkaTemplate,
+                                    DataSourceErrorLogRepository errorLogRepository) {
+        this.kafkaTemplate = kafkaTemplate;
         this.errorLogRepository = errorLogRepository;
     }
 
-    // Перехватывает исключения при выполнении любых методов CRUD в репозиториях
-    @AfterThrowing(pointcut = "execution(* ru.t1.java.demo.repository.*.*(..))", throwing = "ex")
-    public void logDataSourceError(Exception ex) {
-        // Создаем новую запись об ошибке
-        DataSourceErrorLog errorLog = DataSourceErrorLog.builder()
-                .message(ex.getMessage())
-                .stackTrace(getStackTraceAsString(ex))
-                .methodSignature("")
-                .build();
 
-        // Сохраняем запись в таблице DataSourceErrorLog
+    @Around("@annotation(LogDataSourceError)")
+    public Object logErrorAndSendToKafka(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            return joinPoint.proceed();
+        } catch (Exception ex) {
+            log.error("Ошибка при выполнении метода: {}", ex.getMessage(), ex);
+            sendErrorToKafka(ex, joinPoint);
+            saveErrorToDatabase(ex, joinPoint);
+            throw ex;
+        }
+    }
+
+    private void sendErrorToKafka(Exception ex, ProceedingJoinPoint joinPoint) {
+        try {
+            String message = String.format(
+                    "Error in method: %s, Message: %s, StackTrace: %s",
+                    joinPoint.getSignature().getName(),
+                    ex.getMessage(),
+                    Arrays.toString(ex.getStackTrace())
+            );
+            Message<String> kafkaMessage = MessageBuilder.withPayload(message)
+                    .setHeader("errorType", "DATA_SOURCE")
+                    .build();
+            kafkaTemplate.send(metricsTopic, String.valueOf(kafkaMessage)).get();
+        } catch (Exception e) {
+            log.error("Не удалось отправить сообщение в Kafka: {}", e.getMessage(), e);
+        }
+    }
+
+    private void saveErrorToDatabase(Exception ex, ProceedingJoinPoint joinPoint) {
+        DataSourceErrorLog errorLog = new DataSourceErrorLog(
+                Arrays.toString(ex.getStackTrace()),
+                ex.getMessage(),
+                joinPoint.getSignature().toString()
+        );
         errorLogRepository.save(errorLog);
     }
-
-    // Преобразование stack trace в строку для сохранения в базе данных
-    private String getStackTraceAsString(Exception ex) {
-        StringBuilder sb = new StringBuilder();
-        for (StackTraceElement element : ex.getStackTrace()) {
-            sb.append(element.toString()).append("\n");
-        }
-        return sb.toString();
-    }
 }
+
+

--- a/src/main/java/ru/t1/java/demo/aop/Metric.java
+++ b/src/main/java/ru/t1/java/demo/aop/Metric.java
@@ -8,6 +8,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Metric {
-    long thresholdMillis();
+    long value();
 }
 

--- a/src/main/java/ru/t1/java/demo/aop/Metric.java
+++ b/src/main/java/ru/t1/java/demo/aop/Metric.java
@@ -1,0 +1,13 @@
+package ru.t1.java.demo.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Metric {
+    long thresholdMillis();
+}
+

--- a/src/main/java/ru/t1/java/demo/aop/MetricAspect.java
+++ b/src/main/java/ru/t1/java/demo/aop/MetricAspect.java
@@ -1,21 +1,15 @@
 package ru.t1.java.demo.aop;
 
 
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-
 @Slf4j
-@Data
 @Aspect
 @Component
 public class MetricAspect {
@@ -25,26 +19,37 @@ public class MetricAspect {
     @Value("${t1.kafka.topic.metrics}")
     private String metricsTopic;
 
+    public MetricAspect(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
     @Around("@annotation(metric)")
     public Object measureMethodExecution(ProceedingJoinPoint joinPoint, Metric metric) throws Throwable {
         long startTime = System.currentTimeMillis();
-        Object result = joinPoint.proceed();
-
-        long endTime = System.currentTimeMillis();
-        long executionTime = endTime - startTime;
-
-        if (executionTime > metric.thresholdMillis()) {
-            String methodName = joinPoint.getSignature().getName();
-            String parameters = Arrays.toString(joinPoint.getArgs());
-
-            String message = String.format("Method %s executed in %d ms. Parameters: %s",
-                    methodName, executionTime, parameters);
-            Message<String> kafkaMessage = MessageBuilder.withPayload(message)
-                    .setHeader("errorType", "METRICS")
-                    .build();
-            kafkaTemplate.send(metricsTopic, String.valueOf(kafkaMessage)).get();
-            log.info("Sent metrics message: {}", message);
+        try {
+            return joinPoint.proceed();
+        } catch (Throwable ex) {
+            log.error("Ошибка выполнения метода {}: {}", joinPoint.getSignature(), ex.getMessage());
+            sendMetricToKafka(joinPoint, System.currentTimeMillis() - startTime, true, ex.getMessage());
+            throw ex;
+        } finally {
+            long executionTime = System.currentTimeMillis() - startTime;
+            if (executionTime > metric.value()) {
+                sendMetricToKafka(joinPoint, executionTime, false, null);
+            }
         }
-        return result;
+    }
+
+    private void sendMetricToKafka(ProceedingJoinPoint joinPoint, long executionTime, boolean isError, String errorMessage) {
+        try {
+            String methodName = joinPoint.getSignature().toShortString();
+            String message = isError
+                    ? String.format("Метод %s завершился с ошибкой: %s. Время выполнения: %d мс", methodName, errorMessage, executionTime)
+                    : String.format("Метод %s превысил время выполнения: %d мс", methodName, executionTime);
+            kafkaTemplate.send(metricsTopic, message);
+        } catch (Exception e) {
+            log.error("Не удалось отправить метрику в Kafka: {}", e.getMessage(), e);
+        }
     }
 }
+

--- a/src/main/java/ru/t1/java/demo/aop/MetricAspect.java
+++ b/src/main/java/ru/t1/java/demo/aop/MetricAspect.java
@@ -1,0 +1,50 @@
+package ru.t1.java.demo.aop;
+
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Slf4j
+@Data
+@Aspect
+@Component
+public class MetricAspect {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Value("${t1.kafka.topic.metrics}")
+    private String metricsTopic;
+
+    @Around("@annotation(metric)")
+    public Object measureMethodExecution(ProceedingJoinPoint joinPoint, Metric metric) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+
+        long endTime = System.currentTimeMillis();
+        long executionTime = endTime - startTime;
+
+        if (executionTime > metric.thresholdMillis()) {
+            String methodName = joinPoint.getSignature().getName();
+            String parameters = Arrays.toString(joinPoint.getArgs());
+
+            String message = String.format("Method %s executed in %d ms. Parameters: %s",
+                    methodName, executionTime, parameters);
+            Message<String> kafkaMessage = MessageBuilder.withPayload(message)
+                    .setHeader("errorType", "METRICS")
+                    .build();
+            kafkaTemplate.send(metricsTopic, String.valueOf(kafkaMessage)).get();
+            log.info("Sent metrics message: {}", message);
+        }
+        return result;
+    }
+}

--- a/src/main/java/ru/t1/java/demo/config/KafkaConfig.java
+++ b/src/main/java/ru/t1/java/demo/config/KafkaConfig.java
@@ -35,12 +35,12 @@ public class KafkaConfig {
     private String maxPollRecords;
     @Value("${t1.kafka.poll.interval.ms}")
     private String maxPollIntervalsMs;
-//    @Value("${t1.kafka.topic.metrics}")
-//    private String metricsTopic;
-//    @Value("${t1.kafka.topic.accounts}")
-//    private String accountsTopic;
-//    @Value("${t1.kafka.topic.transactions}")
-//    private String transactionsTopic;
+    @Value("${t1.kafka.topic.metrics}")
+    private String metricsTopic;
+    @Value("${t1.kafka.topic.accounts}")
+    private String accountsTopic;
+    @Value("${t1.kafka.topic.transactions}")
+    private String transactionsTopic;
 
 
     @Bean

--- a/src/main/java/ru/t1/java/demo/config/KafkaConfig.java
+++ b/src/main/java/ru/t1/java/demo/config/KafkaConfig.java
@@ -8,12 +8,9 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ContainerProperties;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
-import org.springframework.kafka.support.serializer.JsonSerializer;
 import ru.t1.java.demo.kafka.KafkaClientProducer;
 
 import java.util.HashMap;

--- a/src/main/java/ru/t1/java/demo/config/KafkaConfig.java
+++ b/src/main/java/ru/t1/java/demo/config/KafkaConfig.java
@@ -1,0 +1,83 @@
+package ru.t1.java.demo.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import ru.t1.java.demo.kafka.KafkaClientProducer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+public class KafkaConfig {
+
+    @Value("${t1.kafka.bootstrap.server}")
+    private String bootstrapServers;
+    @Value("${t1.kafka.consumer.group-id}")
+    private String groupId;
+    @Value("${t1.kafka.session.timeout.ms}")
+    private String sessionTimeout;
+    @Value("${t1.kafka.max.partition.fetch.bytes}")
+    private String maxPartitionFetchBytes;
+    @Value("${t1.kafka.max.poll.records}")
+    private String maxPollRecords;
+    @Value("${t1.kafka.poll.interval.ms}")
+    private String maxPollIntervalsMs;
+//    @Value("${t1.kafka.topic.metrics}")
+//    private String metricsTopic;
+//    @Value("${t1.kafka.topic.accounts}")
+//    private String accountsTopic;
+//    @Value("${t1.kafka.topic.transactions}")
+//    private String transactionsTopic;
+
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, sessionTimeout);
+        props.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, maxPartitionFetchBytes);
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollIntervalsMs);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setConcurrency(3);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        return factory;
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        Map<String, Object> producerProps = new HashMap<>();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(producerProps));
+    }
+
+    @Bean
+    public KafkaClientProducer<String> producer() {
+        return new KafkaClientProducer<>(kafkaTemplate());
+    }
+}
+

--- a/src/main/java/ru/t1/java/demo/config/KafkaConsumerConfig.java
+++ b/src/main/java/ru/t1/java/demo/config/KafkaConsumerConfig.java
@@ -1,0 +1,90 @@
+package ru.t1.java.demo.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import ru.t1.java.demo.dto.AccountDto;
+import ru.t1.java.demo.dto.TransactionDto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${t1.kafka.bootstrap.server}")
+    private String bootstrapServers;
+
+    @Value("${t1.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Value("${t1.kafka.session.timeout.ms}")
+    private String sessionTimeout;
+
+    @Value("${t1.kafka.max.partition.fetch.bytes}")
+    private String maxPartitionFetchBytes;
+
+    @Value("${t1.kafka.max.poll.records}")
+    private String maxPollRecords;
+
+    @Value("${t1.kafka.max.poll.interval.ms}")
+    private String maxPollIntervalsMs;
+
+    @Value("${t1.kafka.topic.accounts}")
+    private String accountsTopic;
+
+    @Value("${t1.kafka.topic.transactions}")
+    private String transactionsTopic;
+
+    @Bean
+    public ConsumerFactory<String, AccountDto> accountConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, AccountDto.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConsumerFactory<String, TransactionDto> transactionConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, TransactionDto.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, AccountDto> accountKafkaListenerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, AccountDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(accountConsumerFactory());
+        factory.setConcurrency(1);
+        factory.getContainerProperties().setPollTimeout(3000);
+        return factory;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, TransactionDto> transactionKafkaListenerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, TransactionDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(transactionConsumerFactory());
+        factory.setConcurrency(1);
+        factory.getContainerProperties().setPollTimeout(3000);
+        return factory;
+    }
+}

--- a/src/main/java/ru/t1/java/demo/dto/AccountDto.java
+++ b/src/main/java/ru/t1/java/demo/dto/AccountDto.java
@@ -8,11 +8,12 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class AccountDto {
-    private long id;
+    private Long accountId;
+    private Long clientId;
     private String accountType;
     private BigDecimal balance;
 }

--- a/src/main/java/ru/t1/java/demo/dto/TransactionDto.java
+++ b/src/main/java/ru/t1/java/demo/dto/TransactionDto.java
@@ -6,13 +6,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class TransactionDto {
-
-    private long id;
+    private Long transactionId;
+    private Long accountId;
     private BigDecimal transactionAmount;
+    private LocalDateTime transactionTime;
 }

--- a/src/main/java/ru/t1/java/demo/kafka/KafkaClientProducer.java
+++ b/src/main/java/ru/t1/java/demo/kafka/KafkaClientProducer.java
@@ -1,0 +1,27 @@
+package ru.t1.java.demo.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaClientProducer<T> {
+
+    private final KafkaTemplate<String, T> template;
+
+    public void sendTo(String topic, T message) {
+        try {
+            template.send(topic, message).get();
+        } catch (Exception ex) {
+            log.error(ex.getMessage(), ex);
+        } finally {
+            template.flush();
+        }
+    }
+
+}

--- a/src/main/java/ru/t1/java/demo/kafka/KafkaListeners.java
+++ b/src/main/java/ru/t1/java/demo/kafka/KafkaListeners.java
@@ -1,0 +1,58 @@
+package ru.t1.java.demo.kafka;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import ru.t1.java.demo.dto.AccountDto;
+import ru.t1.java.demo.dto.TransactionDto;
+import ru.t1.java.demo.model.Account;
+import ru.t1.java.demo.model.AccountType;
+import ru.t1.java.demo.model.Client;
+import ru.t1.java.demo.model.Transaction;
+import ru.t1.java.demo.repository.AccountRepository;
+import ru.t1.java.demo.repository.ClientRepository;
+import ru.t1.java.demo.repository.TransactionRepository;
+
+@Slf4j
+@Data
+@Component
+public class KafkaListeners {
+
+    private final AccountRepository accountRepository;
+    private final TransactionRepository transactionRepository;
+    private final ClientRepository clientRepository;
+
+    @KafkaListener(topics = "${t1.kafka.topic.accounts}", groupId = "${t1.kafka.consumer.group-id}")
+    public void listenAccount(AccountDto accountDto) {
+        log.info("Received Account message: {}", accountDto);
+
+        Client client = clientRepository.findById(accountDto.getClientId()).orElseThrow(() -> new RuntimeException("Client not found"));
+
+        Account account = Account.builder()
+                .clientId(client)
+                .accountType(AccountType.valueOf(accountDto.getAccountType()))
+                .balance(accountDto.getBalance())
+                .build();
+
+        accountRepository.save(account);
+        log.info("Saved Account to DB: {}", account);
+    }
+
+    // Слушаем топик t1_demo_transactions
+    @KafkaListener(topics = "${t1.kafka.topic.transactions}", groupId = "${t1.kafka.consumer.group-id}")
+    public void listenTransaction(TransactionDto transactionDto) {
+        log.info("Received Transaction message: {}", transactionDto);
+
+        Account account = accountRepository.findById(transactionDto.getAccountId()).orElseThrow(() -> new RuntimeException("Account not found"));
+
+        Transaction transaction = Transaction.builder()
+                .accountId(account)
+                .transactionAmount(transactionDto.getTransactionAmount())
+                .transactionTime(transactionDto.getTransactionTime())
+                .build();
+
+        transactionRepository.save(transaction);
+        log.info("Saved Transaction to DB: {}", transaction);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,8 @@ t1:
       server: ${KAFKA_SERVER:localhost:9092}
     consumer:
       group-id: t1-demo
+      enable-auto-commit: false
+      auto-offset-reset: earliest
       max.poll.records: 10
     producer:
       enable: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,8 +12,40 @@ spring:
 
 logging:
   level:
-    ROOT: INFO
+    ROOT: DEBUG
     ru.t1.java.demo.controller.ClientController: DEBUG
+    org.apache.kafka: INFO
+    org.hibernate.SQL: INFO
 
 t1:
   scan-path: ru.t1.java.demo
+  kafka:
+    bootstrap:
+      server: ${KAFKA_SERVER:localhost:9092}
+    consumer:
+      group-id: t1-demo
+      max.poll.records: 10
+    producer:
+      enable: true
+    topic:
+      client_registration: t1_demo_client_registration
+      client_id_registered: t1_demo_client_registered
+      client_transactions: t1_demo_client_transactions
+      metrics: t1_demo_metrics
+      accounts: t1_demo_accounts
+      transactions: t1_demo_transactions
+    listener:
+      poll-timeout: 1000
+
+
+track:
+  errors-to-track: JsonParseException, IOException
+  kafka:
+    enabled: ${TRACK_KAFKA_LOG_ENABLED:true}
+    bootstrap-server: localhost:9092
+    data-source-error-topic: t1_demo_data_source_error
+    time-limit-exceed: t1_demo_time_limit_exceed
+  db:
+    enabled: false
+  time-limit-exceed: 1000
+  log-level: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,17 @@ t1:
   kafka:
     bootstrap:
       server: ${KAFKA_SERVER:localhost:9092}
+    session:
+      timeout:
+        ms: 15000
+    max:
+      partition:
+        fetch:
+          bytes: 300000
+    poll:
+      records: 1
+      interval:
+        ms: 3000
     consumer:
       group-id: t1-demo
       enable-auto-commit: false


### PR DESCRIPTION
Реализовал вторую задачу, в которой мы тренировали отправку сообщений в кафку и слушание из топиков. В docker-compose были добавлены zookeeper и два брокера для возможности репликации. Обновлён application.yml(тут мы указали важные настройки, такие как сервер ид группы, десериалайзер(стандартный StringDeserializer), max-poll и интервал и тайм-аут).
Далее я написал конфиг для кафки и кастомные конфиги для консьюмеров, которые работают с новыми топиками. 
Был переделан аспект для логов ошибок, теперь ещё отправляет сообщение в кафку, а при ошибке записывают её в БД. Так же написан аспект Metric, он работает с тем же топиком, по большому счёту он нужен нам для определения плохо работающих методов(собираем метрики). Если метод отрабатывает долго, он отправляет время работы метода в мс в Кафку.
Наконец я разработал листнер для обработки сообщений из топиков и записи в БД.
Так как я работал с микросервисами только с помощью Redis до этого(не самая лучшая практика, но как обычный канал кинуть от одного сервиса к другому в небольшом проекте хорош, ещё и работает быстрее, так как заморочек меньше значительно), я немного терялся именно в Кафке и делал структуру, как в прошлом проекте
